### PR TITLE
Better handling of DATABASES and CACHES

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/pydantic_settings/default.py
+++ b/pydantic_settings/default.py
@@ -51,7 +51,7 @@ class DjangoDefaultProjectSettings(PydanticSettings):
         "django.middleware.clickjacking.XFrameOptionsMiddleware",
     ]
 
-    AUTH_PASSWORD_VALIDATORS = [
+    AUTH_PASSWORD_VALIDATORS: list[dict] = [
         {
             "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
         },

--- a/pydantic_settings/default.py
+++ b/pydantic_settings/default.py
@@ -1,6 +1,12 @@
-from pydantic_settings.database import DatabaseSettings
+from pydantic import Field
+
+from pydantic_settings.database import DatabaseDsn, DatabaseSettings
 from pydantic_settings.models import TemplateBackendModel
 from pydantic_settings.settings import PydanticSettings
+
+
+class DefaultDatabaseSettings(DatabaseSettings):
+    default: DatabaseDsn = Field(env="DATABASE_URL", default="sqlite:///db.sqlite3")
 
 
 class DjangoDefaultProjectSettings(PydanticSettings):
@@ -9,9 +15,7 @@ class DjangoDefaultProjectSettings(PydanticSettings):
     generates for new projects.
     """
 
-    DATABASES: DatabaseSettings = DatabaseSettings.parse_obj(
-        {"default": "sqlite:///db.sqlite3"}
-    )
+    DATABASES: DefaultDatabaseSettings = DefaultDatabaseSettings()
 
     TEMPLATES: list[TemplateBackendModel] = [
         TemplateBackendModel.parse_obj(data)

--- a/pydantic_settings/default.py
+++ b/pydantic_settings/default.py
@@ -1,0 +1,74 @@
+from pydantic_settings.database import DatabaseSettings
+from pydantic_settings.models import TemplateBackendModel
+from pydantic_settings.settings import PydanticSettings
+
+
+class DjangoDefaultProjectSettings(PydanticSettings):
+    """
+    An example of a PydanticSettings subclass that uses the default settings Django
+    generates for new projects.
+    """
+
+    DATABASES: DatabaseSettings = DatabaseSettings.parse_obj(
+        {"default": "sqlite:///db.sqlite3"}
+    )
+
+    TEMPLATES: list[TemplateBackendModel] = [
+        TemplateBackendModel.parse_obj(data)
+        for data in [
+            {
+                "BACKEND": "django.template.backends.django.DjangoTemplates",
+                "DIRS": [],
+                "APP_DIRS": True,
+                "OPTIONS": {
+                    "context_processors": [
+                        "django.template.context_processors.debug",
+                        "django.template.context_processors.request",
+                        "django.contrib.auth.context_processors.auth",
+                        "django.contrib.messages.context_processors.messages",
+                    ],
+                },
+            },
+        ]
+    ]
+
+    INSTALLED_APPS: list[str] = [
+        "django.contrib.admin",
+        "django.contrib.auth",
+        "django.contrib.contenttypes",
+        "django.contrib.sessions",
+        "django.contrib.messages",
+        "django.contrib.staticfiles",
+    ]
+
+    MIDDLEWARE: list[str] = [
+        "django.middleware.security.SecurityMiddleware",
+        "django.contrib.sessions.middleware.SessionMiddleware",
+        "django.middleware.common.CommonMiddleware",
+        "django.middleware.csrf.CsrfViewMiddleware",
+        "django.contrib.auth.middleware.AuthenticationMiddleware",
+        "django.contrib.messages.middleware.MessageMiddleware",
+        "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    ]
+
+    AUTH_PASSWORD_VALIDATORS = [
+        {
+            "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+        },
+        {
+            "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+        },
+        {
+            "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
+        },
+        {
+            "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
+        },
+    ]
+
+    TIME_ZONE: str = "UTC"
+    USE_TZ: bool = True
+
+    STATIC_URL: str = "static/"
+
+    DEFAULT_AUTO_FIELD: str = "django.db.models.BigAutoField"

--- a/pydantic_settings/default.py
+++ b/pydantic_settings/default.py
@@ -10,30 +10,25 @@ class DjangoDefaultProjectSettings(PydanticSettings):
     generates for new projects.
     """
 
-    DATABASES: dict[Any, DatabaseModel] = {
-        "default": "sqlite:///db.sqlite3"  # type: ignore
-    }
+    DATABASES = {"default": "sqlite:///db.sqlite3"}  # type: ignore
 
-    TEMPLATES: list[TemplateBackendModel] = [
-        TemplateBackendModel.parse_obj(data)
-        for data in [
-            {
-                "BACKEND": "django.template.backends.django.DjangoTemplates",
-                "DIRS": [],
-                "APP_DIRS": True,
-                "OPTIONS": {
-                    "context_processors": [
-                        "django.template.context_processors.debug",
-                        "django.template.context_processors.request",
-                        "django.contrib.auth.context_processors.auth",
-                        "django.contrib.messages.context_processors.messages",
-                    ],
-                },
+    TEMPLATES = [
+        {  # type: ignore
+            "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "DIRS": [],
+            "APP_DIRS": True,
+            "OPTIONS": {
+                "context_processors": [
+                    "django.template.context_processors.debug",
+                    "django.template.context_processors.request",
+                    "django.contrib.auth.context_processors.auth",
+                    "django.contrib.messages.context_processors.messages",
+                ],
             },
-        ]
+        },
     ]
 
-    INSTALLED_APPS: list[str] = [
+    INSTALLED_APPS = [
         "django.contrib.admin",
         "django.contrib.auth",
         "django.contrib.contenttypes",
@@ -42,7 +37,7 @@ class DjangoDefaultProjectSettings(PydanticSettings):
         "django.contrib.staticfiles",
     ]
 
-    MIDDLEWARE: list[str] = [
+    MIDDLEWARE = [
         "django.middleware.security.SecurityMiddleware",
         "django.contrib.sessions.middleware.SessionMiddleware",
         "django.middleware.common.CommonMiddleware",
@@ -52,7 +47,7 @@ class DjangoDefaultProjectSettings(PydanticSettings):
         "django.middleware.clickjacking.XFrameOptionsMiddleware",
     ]
 
-    AUTH_PASSWORD_VALIDATORS: list[dict] = [
+    AUTH_PASSWORD_VALIDATORS = [
         {
             "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
         },
@@ -67,9 +62,9 @@ class DjangoDefaultProjectSettings(PydanticSettings):
         },
     ]
 
-    TIME_ZONE: str = "UTC"
-    USE_TZ: bool = True
+    TIME_ZONE = "UTC"
+    USE_TZ = True
 
-    STATIC_URL: str = "static/"
+    STATIC_URL = "static/"
 
-    DEFAULT_AUTO_FIELD: str = "django.db.models.BigAutoField"
+    DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/pydantic_settings/default.py
+++ b/pydantic_settings/default.py
@@ -1,12 +1,7 @@
-from pydantic import Field
+from typing import Any
 
-from pydantic_settings.database import DatabaseDsn, DatabaseSettings
-from pydantic_settings.models import TemplateBackendModel
+from pydantic_settings.models import DatabaseModel, TemplateBackendModel
 from pydantic_settings.settings import PydanticSettings
-
-
-class DefaultDatabaseSettings(DatabaseSettings):
-    default: DatabaseDsn = Field(env="DATABASE_URL", default="sqlite:///db.sqlite3")
 
 
 class DjangoDefaultProjectSettings(PydanticSettings):
@@ -15,7 +10,9 @@ class DjangoDefaultProjectSettings(PydanticSettings):
     generates for new projects.
     """
 
-    DATABASES: DefaultDatabaseSettings = DefaultDatabaseSettings()
+    DATABASES: dict[Any, DatabaseModel] = {
+        "default": "sqlite:///db.sqlite3"  # type: ignore
+    }
 
     TEMPLATES: list[TemplateBackendModel] = [
         TemplateBackendModel.parse_obj(data)

--- a/pydantic_settings/models.py
+++ b/pydantic_settings/models.py
@@ -1,12 +1,7 @@
-from typing import Dict, List, Optional
+from typing import List, Optional, TypedDict
 
 from pydantic import DirectoryPath
 from pydantic.main import BaseModel
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 
 class TemplateBackendModel(BaseModel):
@@ -17,5 +12,54 @@ class TemplateBackendModel(BaseModel):
     OPTIONS: Optional[dict]
 
 
-class CacheBackendModel(BaseModel):
-    default: Dict[Literal["BACKEND"], str]
+class CacheModel(BaseModel):
+    BACKEND: str
+    KEY_FUNCTION: Optional[str] = None
+    KEY_PREFIX: str = ""
+    LOCATION: str = ""
+    OPTIONS: Optional[dict] = None
+    TIMEOUT: Optional[int] = None
+    VERSION: int = 1
+
+
+class DatabateTestDict(TypedDict):
+    CHARSET: Optional[str]
+    COLLATION: Optional[str]
+    DEPENDENCIES: Optional[List[str]]
+    MIGRATE: bool
+    MIRROR: Optional[str]
+    NAME: Optional[str]
+    SERIALIZE: Optional[bool]  # Deprecated since v4.0
+    TEMPLATE: Optional[str]
+    CREATE_DB: Optional[bool]
+    CREATE_USER: Optional[bool]
+    USER: Optional[str]
+    PASSWORD: Optional[str]
+    ORACLE_MANAGED_FILES: Optional[bool]
+    TBLSPACE: Optional[str]
+    TBLSPACE_TMP: Optional[str]
+    DATAFILE: Optional[str]
+    DATAFILE_TMP: Optional[str]
+    DATAFILE_MAXSIZE: Optional[str]
+    DATAFILE_TMP_MAXSIZE: Optional[str]
+    DATAFILE_SIZE: Optional[str]
+    DATAFILE_TMP_SIZE: Optional[str]
+    DATAFILE_EXTSIZE: Optional[str]
+    DATAFILE_TMP_EXTSIZE: Optional[str]
+
+
+class DatabaseModel(BaseModel):
+    ATOMIC_REQUESTS: bool = False
+    AUTOCOMMIT: bool = True
+    ENGINE: str
+    HOST: str = ""
+    NAME: str = ""
+    CONN_MAX_AGE: int = 0
+    OPTIONS: dict = {}
+    PASSWORD: str = ""
+    PORT: str = ""
+    TIME_ZONE: Optional[str] = None
+    DISABLE_SERVER_SIDE_CURSORS: bool = False
+    USER: str = ""
+    TEST: Optional[DatabateTestDict]
+    DATA_UPLOAD_MEMORY_MAX_SIZE: Optional[int]

--- a/pydantic_settings/models.py
+++ b/pydantic_settings/models.py
@@ -1,0 +1,21 @@
+from typing import Dict, List, Optional
+
+from pydantic import DirectoryPath
+from pydantic.main import BaseModel
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
+
+class TemplateBackendModel(BaseModel):
+    BACKEND: str
+    NAME: Optional[str]
+    DIRS: Optional[List[DirectoryPath]]
+    APP_DIRS: Optional[bool]
+    OPTIONS: Optional[dict]
+
+
+class CacheBackendModel(BaseModel):
+    default: Dict[Literal["BACKEND"], str]

--- a/pydantic_settings/settings.py
+++ b/pydantic_settings/settings.py
@@ -113,11 +113,13 @@ class PydanticSettings(BaseSettings):
     ADMINS: Optional[List[Tuple[str, EmailStr]]] = _get_default_setting("ADMIN")
     INTERNAL_IPS: Optional[List[IPvAnyAddress]] = _get_default_setting("INTERNAL_IPS")
 
-    # Would be nice to do something like Union[Literal["*"], IPvAnyAddress, AnyUrl], but there are a lot of different
-    # options that need to be valid and don't necessarily fit those types.
+    # Would be nice to do something like Union[Literal["*"], IPvAnyAddress, AnyUrl], but
+    # there are a lot of different options that need to be valid and don't necessarily
+    # fit those types.
     ALLOWED_HOSTS: Optional[List[str]] = global_settings.ALLOWED_HOSTS
 
-    # Validate against actual list of valid TZs? https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
+    # Validate against actual list of valid TZs?
+    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
     TIME_ZONE: Optional[str] = global_settings.TIME_ZONE
     USE_TZ: Optional[bool]
 
@@ -149,7 +151,9 @@ class PydanticSettings(BaseSettings):
     ] = global_settings.SERVER_EMAIL  # type: ignore
 
     DATABASES: Optional[DatabaseSettings] = Field({})
-    DATABASE_ROUTERS: Optional[List[str]] = global_settings.DATABASE_ROUTERS  # type: ignore
+    DATABASE_ROUTERS: Optional[
+        List[str]
+    ] = global_settings.DATABASE_ROUTERS  # type: ignore
     EMAIL_BACKEND: Optional[str] = global_settings.EMAIL_BACKEND
     EMAIL_HOST: Optional[str] = global_settings.EMAIL_HOST
     EMAIL_PORT: Optional[int] = global_settings.EMAIL_PORT
@@ -158,11 +162,17 @@ class PydanticSettings(BaseSettings):
     EMAIL_HOST_PASSWORD: Optional[str] = global_settings.EMAIL_HOST_PASSWORD
     EMAIL_USE_TLS: Optional[bool] = global_settings.EMAIL_USE_TLS
     EMAIL_USE_SSL: Optional[bool] = global_settings.EMAIL_USE_SSL
-    EMAIL_SSL_CERTFILE: Optional[FilePath] = global_settings.EMAIL_SSL_CERTFILE  # type: ignore
-    EMAIL_SSL_KEYFILE: Optional[FilePath] = global_settings.EMAIL_SSL_KEYFILE  # type: ignore
+    EMAIL_SSL_CERTFILE: Optional[
+        FilePath
+    ] = global_settings.EMAIL_SSL_CERTFILE  # type: ignore
+    EMAIL_SSL_KEYFILE: Optional[
+        FilePath
+    ] = global_settings.EMAIL_SSL_KEYFILE  # type: ignore
     EMAIL_TIMEOUT: Optional[int] = global_settings.EMAIL_TIMEOUT
     INSTALLED_APPS: Optional[List[str]] = global_settings.INSTALLED_APPS
-    TEMPLATES: Optional[List[TemplateBackendModel]] = global_settings.TEMPLATES  # type: ignore
+    TEMPLATES: Optional[
+        List[TemplateBackendModel]
+    ] = global_settings.TEMPLATES  # type: ignore
     FORM_RENDERER: Optional[str] = global_settings.FORM_RENDERER
     DEFAULT_FROM_EMAIL: Optional[str] = global_settings.DEFAULT_FROM_EMAIL
     EMAIL_SUBJECT_PREFIX: Optional[str] = global_settings.EMAIL_SUBJECT_PREFIX
@@ -192,7 +202,9 @@ class PydanticSettings(BaseSettings):
     DATA_UPLOAD_MAX_NUMBER_FIELDS: Optional[
         int
     ] = global_settings.DATA_UPLOAD_MAX_NUMBER_FIELDS
-    FILE_UPLOAD_TEMP_DIR: Optional[DirectoryPath] = global_settings.FILE_UPLOAD_TEMP_DIR  # type: ignore
+    FILE_UPLOAD_TEMP_DIR: Optional[
+        DirectoryPath
+    ] = global_settings.FILE_UPLOAD_TEMP_DIR  # type: ignore
     FILE_UPLOAD_PERMISSIONS: Optional[int] = global_settings.FILE_UPLOAD_PERMISSIONS
     FILE_UPLOAD_DIRECTORY_PERMISSIONS: Optional[
         int
@@ -244,7 +256,9 @@ class PydanticSettings(BaseSettings):
         bool
     ] = global_settings.SESSION_EXPIRE_AT_BROWSER_CLOSE
     SESSION_ENGINE: Optional[str] = global_settings.SESSION_ENGINE
-    SESSION_FILE_PATH: Optional[DirectoryPath] = global_settings.SESSION_FILE_PATH  # type: ignore
+    SESSION_FILE_PATH: Optional[
+        DirectoryPath
+    ] = global_settings.SESSION_FILE_PATH  # type: ignore
     SESSION_SERIALIZER: Optional[str] = global_settings.SESSION_SERIALIZER
     CACHES: Optional[CacheBackendModel] = global_settings.CACHES  # type: ignore
     CACHE_MIDDLEWARE_KEY_PREFIX: Optional[
@@ -297,8 +311,12 @@ class PydanticSettings(BaseSettings):
     TEST_NON_SERIALIZED_APPS: Optional[
         List[str]
     ] = global_settings.TEST_NON_SERIALIZED_APPS
-    FIXTURE_DIRS: Optional[List[DirectoryPath]] = global_settings.FIXTURE_DIRS  # type: ignore
-    STATICFILES_DIRS: Optional[List[DirectoryPath]] = global_settings.STATICFILES_DIRS  # type: ignore
+    FIXTURE_DIRS: Optional[
+        List[DirectoryPath]
+    ] = global_settings.FIXTURE_DIRS  # type: ignore
+    STATICFILES_DIRS: Optional[
+        List[DirectoryPath]
+    ] = global_settings.STATICFILES_DIRS  # type: ignore
     STATICFILES_STORAGE: Optional[str] = global_settings.STATICFILES_STORAGE
     STATICFILES_FINDERS: Optional[List[str]] = global_settings.STATICFILES_FINDERS
     MIGRATION_MODULES: Optional[Dict[str, str]] = global_settings.MIGRATION_MODULES
@@ -314,7 +332,9 @@ class PydanticSettings(BaseSettings):
     ] = global_settings.SECURE_HSTS_INCLUDE_SUBDOMAINS
     SECURE_HSTS_PRELOAD: Optional[bool] = global_settings.SECURE_HSTS_PRELOAD
     SECURE_HSTS_SECONDS: Optional[int] = global_settings.SECURE_HSTS_SECONDS
-    SECURE_REDIRECT_EXEMPT: Optional[List[Pattern]] = global_settings.SECURE_REDIRECT_EXEMPT  # type: ignore
+    SECURE_REDIRECT_EXEMPT: Optional[
+        List[Pattern]
+    ] = global_settings.SECURE_REDIRECT_EXEMPT  # type: ignore
     SECURE_REFERRER_POLICY: Optional[
         Literal[
             "no-referrer",

--- a/pydantic_settings/settings.py
+++ b/pydantic_settings/settings.py
@@ -104,7 +104,7 @@ def _get_default_setting(setting: str) -> Any:
 
 
 class PydanticSettings(BaseSettings):
-    BASE_DIR: Optional[DirectoryPath]
+    BASE_DIR: Optional[DirectoryPath] = None
 
     DEBUG: Optional[bool] = global_settings.DEBUG
     DEBUG_PROPAGATE_EXCEPTIONS: Optional[
@@ -229,7 +229,7 @@ class PydanticSettings(BaseSettings):
     X_FRAME_OPTIONS: Optional[str] = global_settings.X_FRAME_OPTIONS
     USE_X_FORWARDED_HOST: Optional[bool] = global_settings.USE_X_FORWARDED_HOST
     USE_X_FORWARDED_PORT: Optional[bool] = global_settings.USE_X_FORWARDED_PORT
-    WSGI_APPLICATION: Optional[str]
+    WSGI_APPLICATION: Optional[str] = None
     SECURE_PROXY_SSL_HEADER: Optional[
         Tuple[str, str]
     ] = global_settings.SECURE_PROXY_SSL_HEADER
@@ -350,7 +350,7 @@ class PydanticSettings(BaseSettings):
     SECURE_SSL_HOST: Optional[str] = global_settings.SECURE_SSL_HOST
     SECURE_SSL_REDIRECT: Optional[bool] = global_settings.SECURE_SSL_REDIRECT
 
-    ROOT_URLCONF: Optional[str]
+    ROOT_URLCONF: Optional[str] = None
     STATIC_URL: Optional[str] = global_settings.STATIC_URL
     USE_I18N: Optional[bool] = global_settings.USE_I18N
     USE_L10N: Optional[bool] = global_settings.USE_L10N

--- a/pydantic_settings/settings.py
+++ b/pydantic_settings/settings.py
@@ -2,19 +2,20 @@ from inspect import getsourcefile
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Pattern, Sequence, Tuple, Union
 
+from django.conf import global_settings, settings
+from django.core.management.utils import get_random_secret_key
+from pydantic import BaseSettings, DirectoryPath, Field, PyObject, validator
+from pydantic.networks import EmailStr, IPvAnyAddress
+from pydantic.types import FilePath
+
+from pydantic_settings.database import DatabaseSettings
+from pydantic_settings.models import CacheBackendModel, TemplateBackendModel
+
 try:
     from typing import Literal
 except ImportError:
     from typing_extensions import Literal
 
-from django.conf import global_settings, settings
-from django.core.management.utils import get_random_secret_key
-from pydantic import BaseSettings, DirectoryPath, Field, PyObject, validator
-from pydantic.main import BaseModel
-from pydantic.networks import EmailStr, IPvAnyAddress
-from pydantic.types import FilePath
-
-from pydantic_settings.database import DatabaseSettings
 
 DEFAULT_SETTINGS_MODULE_FIELD = Field(
     "pydantic_settings.settings.PydanticSettings", env="DJANGO_SETTINGS_MODULE"
@@ -52,18 +53,6 @@ class SetUp(BaseSettings):
                 )
 
             settings.configure(**settings_dict)
-
-
-class TemplateBackendModel(BaseModel):
-    BACKEND: str
-    NAME: Optional[str]
-    DIRS: Optional[List[DirectoryPath]]
-    APP_DIRS: Optional[bool]
-    OPTIONS: Optional[dict]
-
-
-class CacheBackendModel(BaseModel):
-    default: Dict[Literal["BACKEND"], str]
 
 
 def _get_default_setting(setting: str) -> Any:

--- a/pydantic_settings/settings.py
+++ b/pydantic_settings/settings.py
@@ -1,4 +1,3 @@
-import urllib.parse
 from inspect import getsourcefile
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Pattern, Sequence, Tuple, Union
@@ -15,7 +14,7 @@ from pydantic.main import BaseModel
 from pydantic.networks import EmailStr, IPvAnyAddress
 from pydantic.types import FilePath
 
-from .database import DatabaseDsn
+from pydantic_settings.database import DatabaseSettings
 
 DEFAULT_SETTINGS_MODULE_FIELD = Field(
     "pydantic_settings.settings.PydanticSettings", env="DJANGO_SETTINGS_MODULE"
@@ -53,38 +52,6 @@ class SetUp(BaseSettings):
                 )
 
             settings.configure(**settings_dict)
-
-
-class DatabaseSettings(BaseSettings):
-    default: Optional[DatabaseDsn] = Field(env="DATABASE_URL")
-
-    @validator("*")
-    def format_database_settings(cls, v):
-        if v is None:
-            return {}
-
-        engines = {
-            "postgres": "django.db.backends.postgresql",
-            "postgis": "django.contrib.gis.db.backends.postgis",
-            "mssql": "sql_server.pyodbc",
-            "mysql": "django.db.backends.mysql",
-            "mysqlgis": "django.contrib.gis.db.backends.mysql",
-            "sqlite": "django.db.backends.sqlite3",
-            "spatialite": "django.contrib.gis.db.backends.spatialite",
-            "oracle": "django.db.backends.oracle",
-            "oraclegis": "django.contrib.gis.db.backends.oracle",
-            "redshift": "django_redshift_backend",
-        }
-
-        return {
-            "NAME": v.path[1:] if v.path.startswith("/") else v.path or "",
-            "USER": v.user or "",
-            "PASSWORD": v.password or "",
-            "HOST": urllib.parse.unquote(v.host) if v.host else "",
-            "PORT": v.port or "",
-            "CONN_MAX_AGE": 0,
-            "ENGINE": engines[v.scheme],
-        }
 
 
 class TemplateBackendModel(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,6 @@ tox = "^3.25.1"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.isort]
+profile = "black"

--- a/settings_test/settings_test/database_settings.py
+++ b/settings_test/settings_test/database_settings.py
@@ -1,13 +1,21 @@
-from pydantic import BaseSettings, Field
+from typing import Optional
+
+from pydantic import Field
+
 from pydantic_settings import PydanticSettings
-from pydantic_settings.settings import DatabaseSettings
 from pydantic_settings.database import DatabaseDsn
 
 
-class Databases(DatabaseSettings):
-    default: DatabaseDsn = Field(env="DATABASE_URL")
-    secondary: DatabaseDsn = Field(env="SECONDARY_DATABASE_URL")
-
-
 class TestSettings(PydanticSettings):
-    DATABASES: Databases = Field({})
+    secondary_database_dsn: Optional[DatabaseDsn] = Field(
+        env="SECONDARY_DATABASE_URL", configure_database="secondary"
+    )
+
+
+if __name__ == "__main__":
+    # Run this file directly with DATABASE_URL and/or SECONDARY_DATABASE_URL environment
+    # variables to test the database settings.
+    settings = TestSettings()
+    import pprint
+
+    pprint.pprint(settings.dict(exclude_defaults=True).get("DATABASES"))


### PR DESCRIPTION
Specifically, `DATABASES` using it's own custom settings means that it wouldn't respect settings related Config changes to the main `PydanticSettings` object.

This is just a better representation of the original.

I'm creating this as just a draft PR for now because it's forked off the `default-settings` branch rather than default, and also the tests now need updating.

