### PR TITLE
Fix inabliity to run Django tests on 0.7

### DIFF
--- a/pydantic_settings/models.py
+++ b/pydantic_settings/models.py
@@ -18,7 +18,7 @@ class CacheModel(BaseModel):
     KEY_FUNCTION: Optional[str] = None
     KEY_PREFIX: str = ""
     LOCATION: str = ""
-    OPTIONS: Optional[dict] = None
+    OPTIONS: dict = {}
     TIMEOUT: Optional[int] = None
     VERSION: int = 1
 
@@ -62,5 +62,5 @@ class DatabaseModel(BaseModel):
     TIME_ZONE: Optional[str] = None
     DISABLE_SERVER_SIDE_CURSORS: bool = False
     USER: str = ""
-    TEST: Optional[DatabateTestDict] = None
+    TEST: DatabateTestDict = {}
     DATA_UPLOAD_MEMORY_MAX_SIZE: Optional[int] = None

--- a/pydantic_settings/models.py
+++ b/pydantic_settings/models.py
@@ -23,7 +23,7 @@ class CacheModel(BaseModel):
     VERSION: int = 1
 
 
-class DatabateTestDict(TypedDict, total=False):
+class DatabaseTestDict(TypedDict, total=False):
     CHARSET: Optional[str]
     COLLATION: Optional[str]
     DEPENDENCIES: Optional[List[str]]
@@ -62,5 +62,5 @@ class DatabaseModel(BaseModel):
     TIME_ZONE: Optional[str] = None
     DISABLE_SERVER_SIDE_CURSORS: bool = False
     USER: str = ""
-    TEST: DatabateTestDict = {}
+    TEST: DatabaseTestDict = {}
     DATA_UPLOAD_MEMORY_MAX_SIZE: Optional[int] = None

--- a/pydantic_settings/settings.py
+++ b/pydantic_settings/settings.py
@@ -337,7 +337,7 @@ class PydanticSettings(BaseSettings):
     default_database_dsn: Optional[DatabaseDsn] = Field(
         env="DATABASE_URL", configure_database="default"
     )
-    default_cache_dsn: Optional[DatabaseDsn] = Field(
+    default_cache_dsn: Optional[CacheDsn] = Field(
         env="CACHE_URL", configure_cache="default"
     )
 
@@ -382,11 +382,10 @@ class PydanticSettings(BaseSettings):
         """
         CACHES = values.get("CACHES") or {}
         for cache_key, attr in cls._get_dsn_fields(field_extra="configure_cache"):
-            if not CACHES.get(cache_key):
-                cache_dsn: Optional[CacheDsn] = values[attr]
-                if cache_dsn:
-                    CACHES = values.setdefault("CACHES", {})
-                    CACHES[cache_key] = cache_dsn.to_settings_model()
+            cache_dsn: Optional[CacheDsn] = values[attr]
+            if cache_dsn:
+                CACHES = values.setdefault("CACHES", {})
+                CACHES[cache_key] = cache_dsn.to_settings_model()
             del values[attr]
         return values
 

--- a/settings_test/tests/test_env.py
+++ b/settings_test/tests/test_env.py
@@ -35,6 +35,12 @@ def test_env_loaded(configure_settings):
     assert settings.DATABASES["default"]["NAME"] == "foo"
 
 
+def test_cache_loaded(configure_settings):
+    configure_settings({"CACHE_URL": "redis:///1"})
+
+    assert "redis" in settings.CACHES["default"]["BACKEND"]
+
+
 def test_env_loaded2(configure_settings):
     configure_settings({"DATABASE_URL": "sqlite:///bar"})
     assert settings.DATABASES["default"]["NAME"] == "bar"


### PR DESCRIPTION
Updating to the new 0.7 version against a codebase resulted in pytest-django failing to be able to run the tests.

There are two `DatabaseModel` and `CacheModel` options that need to be dictionaries to work with django's test framework.